### PR TITLE
Fixed compatibility with VS 2012 and removed x64 (not supported @MS yet)

### DIFF
--- a/src/RedisIntegration/HostManager.cs
+++ b/src/RedisIntegration/HostManager.cs
@@ -66,8 +66,9 @@ namespace RedisIntegration
 			var asm = typeof(HostManager).Assembly;
 			for (int i = 1; i < 6; ++i)
 			{
-				string machineBits = (Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE") == "x86" && Environment.GetEnvironmentVariable("PROCESSOR_ARCHITEW6432") == null) 
-					? "32bit" : "64bit";
+				string machineBits = "32bit";
+					//(Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE") == "x86" && Environment.GetEnvironmentVariable("PROCESSOR_ARCHITEW6432") == null) 
+					//? "32bit" : "64bit";
 				var pathBits = new[] { Path.GetDirectoryName(asm.Location) }.Concat(Enumerable.Repeat("..", i))
 					.Concat(new[] {"packages", "RedisIntegration." + asm.GetName().Version.ToString(4), "tools", machineBits });
 				sourceDirectory = Path.Combine(pathBits.ToArray());

--- a/src/RedisIntegration/HostManager.cs
+++ b/src/RedisIntegration/HostManager.cs
@@ -8,6 +8,8 @@ using System.Linq;
 using System.Net.Sockets;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Collections.Generic;
+using System.Threading;
 
 namespace RedisIntegration
 {
@@ -59,43 +61,50 @@ namespace RedisIntegration
 		[SuppressMessage("Gendarme.Rules.Correctness", "EnsureLocalDisposalRule", Justification = "The HostController now owns the Process and its finalizer disposes it")]
 		private static HostProcessController StartRedisInstance(string host, int port, bool visible)
 		{
-			string tempPath = Path.GetTempPath();
-
-			string sourceDirectory = string.Empty;
-			//sniff up the directory tree just in case something weird is going on
 			var asm = typeof(HostManager).Assembly;
-			for (int i = 1; i < 6; ++i)
-			{
-				string machineBits = "32bit";
-					//(Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE") == "x86" && Environment.GetEnvironmentVariable("PROCESSOR_ARCHITEW6432") == null) 
-					//? "32bit" : "64bit";
-				var pathBits = new[] { Path.GetDirectoryName(asm.Location) }.Concat(Enumerable.Repeat("..", i))
-					.Concat(new[] {"packages", "RedisIntegration." + asm.GetName().Version.ToString(4), "tools", machineBits });
-				sourceDirectory = Path.Combine(pathBits.ToArray());
+			
+			var redisServerFileName = "redis-server.exe";
+			var redisConfFileName = "redis.conf";
+			string targetFilePath = Path.Combine(Path.GetTempPath(), "RedisIntegration");
+			if(!Directory.Exists(targetFilePath))
+				Directory.CreateDirectory(targetFilePath);
 
-				if (Directory.Exists(sourceDirectory))
-					break;
+			var resNameServer = asm.GetManifestResourceNames().First(s => s.ToLower().Contains(redisServerFileName));
+			var resNameConf = asm.GetManifestResourceNames().First(s => s.ToLower().Contains(redisConfFileName));
+			
+			Dictionary<string, string> resToFile = new Dictionary<string,string>();
+			resToFile.Add(resNameServer, redisServerFileName);
+			resToFile.Add(resNameConf, redisConfFileName);
+
+			foreach(var res in new []{resNameServer, resNameConf})
+			{
+				using(var reader = new BinaryReader(asm.GetManifestResourceStream(res)))
+				{
+					File.WriteAllBytes(Path.Combine(targetFilePath, resToFile[res]), reader.ReadBytes((int)reader.BaseStream.Length));
+				}
 			}
 
-			//copy to our temp folder
-			foreach (var fileName in new [] { "redis-server.exe" })
-				File.Copy(Path.Combine(sourceDirectory, fileName), Path.Combine(tempPath, fileName), true);
+			var redisServerFullPath = Path.Combine(targetFilePath, redisServerFileName);
+			var redisConfFullPath = Path.Combine(targetFilePath, redisConfFileName);
 
-			string databaseFilePath = Path.GetTempFileName().Replace(".tmp", ".rdb");
+			if(!File.Exists(redisServerFullPath))
+				throw new FileNotFoundException(string.Format("redis-server.exe was not found at expected path: {0}", redisServerFullPath));
+			if(!File.Exists(redisConfFullPath))
+				throw new FileNotFoundException(string.Format("redis.conf was not found at expected path: {0}", redisConfFullPath));
 
-			string configuration = File.ReadAllText(Path.Combine(sourceDirectory, "redis.conf"));
+			string databaseFilePath = Path.Combine(targetFilePath, Path.GetFileName(Path.GetTempFileName().Replace(".tmp", ".rdb")));
+
+			string configuration = File.ReadAllText(redisConfFullPath);
 
 			//put in our specific environment info
 			configuration = Regex.Replace(configuration, "port 6379", String.Format(CultureInfo.InvariantCulture, "port {0}", port));
 			configuration = Regex.Replace(configuration, "databases 16", "databases 1");
-			configuration = Regex.Replace(configuration, @"dbfilename dump\.rdb", String.Format(CultureInfo.InvariantCulture, "dbfilename {0}", Path.
-			GetFileName(databaseFilePath)));
-			configuration = Regex.Replace(configuration, @"dir \./", String.Format(CultureInfo.InvariantCulture, "dir {0}", tempPath));
+			configuration = Regex.Replace(configuration, @"dbfilename dump\.rdb", String.Format(CultureInfo.InvariantCulture, "dbfilename {0}", Path.GetFileName(databaseFilePath)));
+			configuration = Regex.Replace(configuration, @"dir \./", String.Format(CultureInfo.InvariantCulture, "dir {0}", targetFilePath));
 
-			string configPath = Path.GetTempFileName().Replace(".tmp", ".conf");
-			File.WriteAllText(configPath, configuration);
+			File.WriteAllText(redisConfFullPath, configuration);
 
-			var processInfo = new ProcessStartInfo(Path.Combine(sourceDirectory, "redis-server.exe"), configPath) { WorkingDirectory = tempPath };
+			var processInfo = new ProcessStartInfo(redisServerFullPath, redisConfFullPath) { WorkingDirectory = targetFilePath };
 			if (!visible)
 			{
 				processInfo.UseShellExecute = false;
@@ -104,15 +113,24 @@ namespace RedisIntegration
 
 			var process = Process.Start(processInfo);
 
+			Thread.Sleep(100);
+
+			if(process.HasExited)
+			{
+				string message = string.Format("Redis-server.exe failed to start.  Exit code: {0}", process.ExitCode);
+
+				throw new Exception(message);
+			}
+
 			//totally clear out any junk we might have in there from old starts with a FLUSHALL
 			using (var client = new TcpClient(host, port))
 			{
 				//http://redis.io/topics/protocol
 				var flushAll = Encoding.ASCII.GetBytes("*1\r\n$8\r\nFLUSHALL\r\n");
 				client.GetStream().Write(flushAll, 0, flushAll.Length);
-			}			
+			}
 
-			return new HostProcessController(databaseFilePath, configPath, host, port, process);
+			return new HostProcessController(databaseFilePath, redisConfFullPath, host, port, process);
 		}
 	}
 }

--- a/src/RedisIntegration/RedisIntegration.csproj
+++ b/src/RedisIntegration/RedisIntegration.csproj
@@ -99,21 +99,11 @@
     <None Include="tools\64bit\libhiredis.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="tools\64bit\redis-benchmark.exe">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="tools\64bit\redis-check-aof.exe">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="tools\64bit\redis-check-dump.exe">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="tools\64bit\redis-cli.exe">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="tools\64bit\redis-server.exe">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    <None Include="tools\64bit\redis-benchmark.exe" />
+    <None Include="tools\64bit\redis-check-aof.exe" />
+    <None Include="tools\64bit\redis-check-dump.exe" />
+    <None Include="tools\64bit\redis-cli.exe" />
+    <None Include="tools\64bit\redis-server.exe" />
     <None Include="tools\README-Windows.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/RedisIntegration/RedisIntegration.csproj
+++ b/src/RedisIntegration/RedisIntegration.csproj
@@ -58,9 +58,9 @@
     <None Include="tools\00-RELEASENOTES">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="tools\32bit\redis.conf">
+    <EmbeddedResource Include="tools\32bit\redis.conf">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    </EmbeddedResource>
     <None Include="tools\64bit\redis.conf">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -93,9 +93,9 @@
     <None Include="tools\32bit\redis-cli.exe">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="tools\32bit\redis-server.exe">
+    <EmbeddedResource Include="tools\32bit\redis-server.exe">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    </EmbeddedResource>
     <None Include="tools\64bit\libhiredis.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/RedisIntegration/tools/32bit/redis.conf
+++ b/src/RedisIntegration/tools/32bit/redis.conf
@@ -369,7 +369,8 @@ slowlog-max-len 1024
 # To enable VM just set 'vm-enabled' to yes, and set the following three
 # VM parameters accordingly to your needs.
 
-vm-enabled no
+# **Not supported in MS Open Tech bins
+# vm-enabled no
 # vm-enabled yes
 
 # This is the path of the Redis swap file. As you can guess, swap files
@@ -383,7 +384,8 @@ vm-enabled no
 # *** WARNING *** if you are using a shared hosting the default of putting
 # the swap file under /tmp is not secure. Create a dir with access granted
 # only to Redis user and configure Redis to create the swap file there.
-vm-swap-file /tmp/redis.swap
+# **Not supported in MS Open Tech bins
+# vm-swap-file /tmp/redis.swap
 
 # vm-max-memory configures the VM to use at max the specified amount of
 # RAM. Everything that deos not fit will be swapped on disk *if* possible, that
@@ -393,7 +395,8 @@ vm-swap-file /tmp/redis.swap
 # default, just specify the max amount of RAM you can in bytes, but it's
 # better to leave some margin. For instance specify an amount of RAM
 # that's more or less between 60 and 80% of your free RAM.
-vm-max-memory 0
+# **Not supported in MS Open Tech bins
+# vm-max-memory 0
 
 # Redis swap files is split into pages. An object can be saved using multiple
 # contiguous pages, but pages can't be shared between different objects.
@@ -404,7 +407,8 @@ vm-max-memory 0
 # If you use a lot of small objects, use a page size of 64 or 32 bytes.
 # If you use a lot of big objects, use a bigger page size.
 # If unsure, use the default :)
-vm-page-size 32
+# **Not supported in MS Open Tech bins
+# vm-page-size 32
 
 # Number of total memory pages in the swap file.
 # Given that the page table (a bitmap of free/used pages) is taken in memory,
@@ -417,7 +421,8 @@ vm-page-size 32
 #
 # It's better to use the smallest acceptable value for your application,
 # but the default is large in order to work in most conditions.
-vm-pages 134217728
+# **Not supported in MS Open Tech bins
+# vm-pages 134217728
 
 # Max number of VM I/O threads running at the same time.
 # This threads are used to read/write data from/to swap file, since they
@@ -428,7 +433,8 @@ vm-pages 134217728
 #
 # The special value of 0 turn off threaded I/O and enables the blocking
 # Virtual Memory implementation.
-vm-max-threads 4
+# **Not supported in MS Open Tech bins
+# vm-max-threads 4
 
 ############################### ADVANCED CONFIG ###############################
 


### PR DESCRIPTION
Original bin's taken from dmajkic's redis port- he now refers MS Open Tech as the official windows port.  Bins should be taken from MS Open Tech who does not _yet_ supply 64bit.  Support for 64bit should be put back when MSOT finishes their 64bit portion of the port.
